### PR TITLE
Colorpicker feature idea: adding quote characters to the string copied.

### DIFF
--- a/thonnycontrib/thonny-py5mode/__init__.py
+++ b/thonnycontrib/thonny-py5mode/__init__.py
@@ -153,9 +153,10 @@ def toggle_py5_imported_mode() -> None:
 
 def color_selector() -> None:
     '''open tkinter color selector put color on clipboard on close'''
-    dialog_result = askcolor(title='Color selector')
-    hex_color_as_string = f"'{dialog_result[1]}'"
-    pyperclip.copy(hex_color_as_string)
+    dialog_result = askcolor(title='Color selector')[1]
+    if dialog_result is not None:
+        hex_color_as_string = f"'{dialog_result}'"
+        pyperclip.copy(hex_color_as_string)
 
 
 def convert_code(translator) -> None:

--- a/thonnycontrib/thonny-py5mode/__init__.py
+++ b/thonnycontrib/thonny-py5mode/__init__.py
@@ -152,8 +152,10 @@ def toggle_py5_imported_mode() -> None:
 
 
 def color_selector() -> None:
-    '''open tkinter color selector'''
-    pyperclip.copy(str(askcolor(title='Color selector')[1]))
+    '''open tkinter color selector put color on clipboard on close'''
+    dialog_result = askcolor(title='Color selector')
+    hex_color_as_string = f"'{dialog_result[1]}'"
+    pyperclip.copy(hex_color_as_string)
 
 
 def convert_code(translator) -> None:


### PR DESCRIPTION
Do you think this is a good idea?

Also, I have changed the text on the selector dialog, but for some reason my git is ignoring that change:
![image](https://user-images.githubusercontent.com/3694604/179405495-5fa78a49-64f8-4086-aa75-2f7d14f443f5.png)

How bad is it to change this "vendorized" color selector?
