### PR TITLE
removing maxsize argument from `get_python_version_string()` call

### DIFF
--- a/thonnycontrib/thonny-py5mode/about_plugin.py
+++ b/thonnycontrib/thonny-py5mode/about_plugin.py
@@ -78,7 +78,7 @@ class AboutDialog(ui_utils.CommonDialog):
           main_frame,
           justify=tk.CENTER,
           text=system_desc
-          + '\n Python ' + get_python_version_string(maxsize=sys.maxsize)
+          + '\n Python ' + get_python_version_string()
           + '\n py5 ' + _PY5_VERSION
           + '\n Thonny ' + get_version()
         )


### PR DESCRIPTION
This fixes https://github.com/tabreturn/thonny-py5mode/issues/59 for me on Thonny 4.1.4

Will it work on earlier versions? I'm not sure.