### PR TITLE
Add JDK version distinction behavior of a minimum version & downloadable version

### DIFF
--- a/thonnycontrib/thonny-py5mode/install_jdk.py
+++ b/thonnycontrib/thonny-py5mode/install_jdk.py
@@ -77,7 +77,7 @@ def is_java_home_set() -> bool:
         if match := JDK_PATTERN.search(java_home):
             system_jdk = match.group(1) # Get JDK version from 1st match group
 
-        if is_valid_jdk_version(system_jdk) and is_validjdk_path(java_home):
+        if is_valid_jdk_version(system_jdk) and is_valid_jdk_path(java_home):
             return True # Version is numeric and meets the minimum requirement
 
     return False # No JAVA_HOME pointing to a required JDK was found
@@ -93,10 +93,10 @@ def get_thonny_jdk_install() -> PurePath | Literal['']:
             # Check JDK major version from 1st match group:
             if is_valid_jdk_version(match.group(1)):
                 # Create a full path by joining THONNY_USER_DIR + folder name:
-                jdk_path = adjustjdk_path(THONNY_USER_PATH / subfolder)
+                jdk_path = adjust_jdk_path(THONNY_USER_PATH / subfolder)
 
                 # Check and return a valid JDK subfolder in THONNY_USER_DIR:
-                if is_validjdk_path(jdk_path): return jdk_path
+                if is_valid_jdk_path(jdk_path): return jdk_path
 
     return '' # No JDK with required version found in THONNY_USER_DIR
 
@@ -104,7 +104,7 @@ def get_thonny_jdk_install() -> PurePath | Literal['']:
 def set_java_home(jdk_path: StrPath) -> None:
     '''Add JDK path to config file (tools > options > general > env vars).'''
 
-    jdk_path = str(adjustjdk_path(jdk_path)) # Platform-adjusted path
+    jdk_path = str(adjust_jdk_path(jdk_path)) # Platform-adjusted path
     env['JAVA_HOME'] = jdk_path # Python's process points to Thonny's JDK too
 
     jdk_path_entry = create_java_home_entry_from_path(jdk_path)
@@ -117,7 +117,7 @@ def set_java_home(jdk_path: StrPath) -> None:
         showinfo('JAVA_HOME', jdk_path, parent=WORKBENCH)
 
 
-def adjustjdk_path(jdk_path: StrPath) -> PurePath:
+def adjust_jdk_path(jdk_path: StrPath) -> PurePath:
     '''Adjust JDK path for the specificity of current platform.'''
 
     jdk_path = PurePath(jdk_path)
@@ -149,7 +149,7 @@ def is_valid_jdk_version(jdk_version: str) -> bool:
     return jdk_version.isdigit() and int(jdk_version) >= REQUIRE_JDK
 
 
-def is_validjdk_path(jdk_path: StrPath) -> bool:
+def is_valid_jdk_path(jdk_path: StrPath) -> bool:
     '''Check if the given path points to a JDK install with a usable Java.'''
     java_compiler = jdk._IS_WINDOWS and 'javac.exe' or 'javac'
     return Path(jdk_path, 'bin', java_compiler).is_file()
@@ -281,19 +281,19 @@ class DownloadJDK(Thread):
         '''Download and setup JDK (installs to Thonny's user directory)'''
 
         # Delete existing Thonny's JDK subfolders matching jdk-<version##>:
-        self.process_matchjdk_dirs(shutil.rmtree)
+        self.process_match_jdk_dirs(shutil.rmtree)
 
         # Download and extract JDK subfolder into Thonny's user folder:
         jdk.install(DOWNLOAD_JDK, path=THONNY_USER_DIR)
 
         # Rename extracted Thonny's JDK subfolder to jdk-<version##>:
-        self.process_matchjdk_dirs(self.rename_folder, True)
+        self.process_match_jdk_dirs(self.rename_folder, True)
 
         set_java_home(JDK_HOME) # Add a Thonny's JAVA_HOME entry for it
 
 
     @staticmethod
-    def process_matchjdk_dirs(action: PathAction, only_1st=False) -> None:
+    def process_match_jdk_dirs(action: PathAction, only_1st=False) -> None:
         '''Apply an action to JDK-matching subfolders in Thonny's folder.'''
 
         for path in DownloadJDK.get_all_thonny_folder_paths():

--- a/thonnycontrib/thonny-py5mode/install_jdk.py
+++ b/thonnycontrib/thonny-py5mode/install_jdk.py
@@ -95,7 +95,7 @@ def get_thonny_jdk_install() -> PurePath | Literal['']:
                 # Create a full path by joining THONNY_USER_DIR + folder name:
                 jdk_path = adjust_jdk_path(THONNY_USER_PATH / subfolder)
 
-                # Check and return a valid JDK subfolder in THONNY_USER_DIR:
+                # Check and return a valid JDK subfolder from THONNY_USER_DIR:
                 if is_valid_jdk_path(jdk_path): return jdk_path
 
     return '' # No JDK with required version found in THONNY_USER_DIR

--- a/thonnycontrib/thonny-py5mode/install_jdk.py
+++ b/thonnycontrib/thonny-py5mode/install_jdk.py
@@ -47,9 +47,6 @@ THONNY_USER_PATH = Path(THONNY_USER_DIR)
 JDK_PATH = THONNY_USER_PATH / JDK_DIR
 '''Path for JDK installation subfolder.'''
 
-JDK_HOME = str(JDK_PATH)
-'''JDK install subfolder's full path string.'''
-
 WORKBENCH = get_workbench()
 '''Thonny's workbench singleton instance.'''
 
@@ -288,7 +285,7 @@ class DownloadJDK(Thread):
         # Rename extracted Thonny's JDK subfolder to jdk-<version##>:
         self.process_match_jdk_dirs(self.rename_folder, True)
 
-        set_java_home(JDK_HOME) # Add a Thonny's JAVA_HOME entry for it
+        set_java_home(JDK_PATH) # Add a Thonny's JAVA_HOME entry for it
 
 
     @staticmethod

--- a/thonnycontrib/thonny-py5mode/install_jdk.py
+++ b/thonnycontrib/thonny-py5mode/install_jdk.py
@@ -107,12 +107,11 @@ def set_java_home(jdk_path: StrPath) -> None:
     jdk_path = str(adjust_jdk_path(jdk_path)) # Platform-adjusted path
     env['JAVA_HOME'] = jdk_path # Python's process points to Thonny's JDK too
 
-    jdk_path_entry = create_java_home_entry_from_path(jdk_path)
+    java_home_entry = create_java_home_entry_from_path(jdk_path)
     env_vars: set[str] = set(WORKBENCH.get_option('general.environment'))
 
-    if jdk_path_entry not in env_vars:
-        entries = [*drop_all_java_home_entries(env_vars)]
-        entries.append(jdk_path_entry)
+    if java_home_entry not in env_vars:
+        entries = [ *drop_all_java_home_entries(env_vars), java_home_entry ]
         WORKBENCH.set_option('general.environment', entries)
         showinfo('JAVA_HOME', jdk_path, parent=WORKBENCH)
 

--- a/thonnycontrib/thonny-py5mode/install_jdk.py
+++ b/thonnycontrib/thonny-py5mode/install_jdk.py
@@ -2,9 +2,7 @@
    checks for JDK and, if not found, installs it to the Thonny config directory
 '''
 
-import re
-import shutil
-import jdk
+import re, shutil, jdk
 
 from pathlib import Path, PurePath
 from threading import Thread
@@ -28,22 +26,23 @@ StrPath: TypeAlias = str | PathLike[str]
 PathAction: TypeAlias = Callable[[StrPath], None]
 '''Represents an action applied to a single path-like object.'''
 
-_JDK_PATTERN = re.compile(r"""
+JDK_PATTERN = re.compile(r"""
     (?:java|jdk)    # Match 'java' or 'jdk' (non-capturing group)
     -?              # Match optional hyphen '-'
     (\d+)           # Capture JDK major version number as group(1)
 """, re.IGNORECASE | re.VERBOSE)
 
-_REQUIRE_JDK, _VERSION_JDK = 17, '17' # Minimum required version
-_JDK_DIR = 'jdk-' + _VERSION_JDK # JDK subfolder name
+REQUIRE_JDK, VERSION_JDK = 17, '17' # Minimum required version
+DOWNLOAD_JDK = '21' # JDK version to download
+JDK_DIR = 'jdk-' + DOWNLOAD_JDK # JDK subfolder name
 
-_THONNY_USER_PATH = Path(THONNY_USER_DIR) # Thonny folder's full path string
-_JDK_PATH = _THONNY_USER_PATH / _JDK_DIR # Path for JDK subfolder
-_JDK_HOME = str(_JDK_PATH) # JDK subfolder's full path string
+THONNY_USER_PATH = Path(THONNY_USER_DIR) # Thonny folder's full path string
+JDK_PATH = THONNY_USER_PATH / JDK_DIR # Path for JDK subfolder
+JDK_HOME = str(JDK_PATH) # JDK subfolder's full path string
 
-workbench = get_workbench() # Workbench singleton instance
+WORKBENCH = get_workbench() # Workbench singleton instance
 
-def install_jdk(): # Module's main entry-point function
+def install_jdk() -> None: # Module's main entry-point function
     '''Call this function from where this module is imported.'''
     if is_java_home_set(): return # JAVA_HOME points to a required JDK version
 
@@ -62,10 +61,10 @@ def is_java_home_set() -> bool:
         if islink(java_home):
             java_home = realpath(java_home) # If symlink, resolve actual path
 
-        if match := _JDK_PATTERN.search(java_home):
+        if match := JDK_PATTERN.search(java_home):
             system_jdk = match.group(1) # Get JDK version from 1st match group
 
-        if is_valid_jdk_version(system_jdk) and is_valid_jdk_path(java_home):
+        if is_valid_jdk_version(system_jdk) and is_validjdk_path(java_home):
             return True # Version is numeric and meets the minimum requirement
 
     return False # No JAVA_HOME pointing to a required JDK was found
@@ -76,39 +75,39 @@ def get_thonny_jdk_install() -> PurePath | Literal['']:
     and return its path. Otherwise, return an empty string.'''
     for subfolder in get_all_thonny_folders(): # Loop over each subfolder name
         # Use regexp to check if subfolder contains a valid JDK name: 
-        if match := _JDK_PATTERN.search(subfolder):
+        if match := JDK_PATTERN.search(subfolder):
             # Check JDK major version from 1st match group:
             if is_valid_jdk_version(match.group(1)):
                 # Create a full path by joining THONNY_USER_DIR + folder name:
-                jdk_path = adjust_jdk_path(_THONNY_USER_PATH / subfolder)
+                jdk_path = adjustjdk_path(THONNY_USER_PATH / subfolder)
 
                 # Check and return a valid JDK subfolder in THONNY_USER_DIR:
-                if is_valid_jdk_path(jdk_path): return jdk_path
+                if is_validjdk_path(jdk_path): return jdk_path
 
     return '' # No JDK with required version found in THONNY_USER_DIR
 
 
-def set_java_home(jdk_path: StrPath):
+def set_java_home(jdk_path: StrPath) -> None:
     '''Add JDK path to config file (tools > options > general > env vars).'''
-    jdk_path = str(adjust_jdk_path(jdk_path))
+    jdk_path = str(adjustjdk_path(jdk_path)) # Platform-adjusted path
     env['JAVA_HOME'] = jdk_path # Python's process points to Thonny's JDK
 
     jdk_path_entry = create_java_home_entry_from_path(jdk_path)
-    env_vars: set[str] = set(workbench.get_option('general.environment'))
+    env_vars: set[str] = set(WORKBENCH.get_option('general.environment'))
 
     if jdk_path_entry not in env_vars:
         entries = [*drop_all_java_home_entries(env_vars)]
         entries.append(jdk_path_entry)
-        workbench.set_option('general.environment', entries)
-        showinfo('JAVA_HOME', jdk_path, parent=workbench)
+        WORKBENCH.set_option('general.environment', entries)
+        showinfo('JAVA_HOME', jdk_path, parent=WORKBENCH)
 
 
-def adjust_jdk_path(jdk_path: StrPath) -> PurePath:
+def adjustjdk_path(jdk_path: StrPath) -> PurePath:
     '''Adjust JDK path for the specificity of current platform.'''
     jdk_path = PurePath(jdk_path)
 
     # if MacOS, append "/Contents/Home/" to form the actual JDK path for it:
-    if jdk.OS is jdk.OperatingSystem.MAC and jdk_path.parts[-1] != 'Home':
+    if jdk.OS is jdk.OperatingSystem.MAC and jdk_path.name != 'Home':
         jdk_path = jdk_path / 'Contents' / 'Home'
 
     return jdk_path
@@ -131,10 +130,10 @@ def _non_java_home_predicate(entry: str) -> bool:
 
 def is_valid_jdk_version(jdk_version: str) -> bool:
     '''Check if JDK version meets minimum version requirement.'''
-    return jdk_version.isdigit() and int(jdk_version) >= _REQUIRE_JDK
+    return jdk_version.isdigit() and int(jdk_version) >= REQUIRE_JDK
 
 
-def is_valid_jdk_path(jdk_path: StrPath) -> bool:
+def is_validjdk_path(jdk_path: StrPath) -> bool:
     '''Check if the given path points to a JDK install with a usable Java.'''
     java_compiler = jdk._IS_WINDOWS and 'javac.exe' or 'javac'
     return Path(jdk_path, 'bin', java_compiler).is_file()
@@ -146,50 +145,6 @@ def get_all_thonny_folders() -> list[str]:
         return sorted((e.name for e in entries if e.is_dir()), reverse=True)
 
 
-class DownloadJDK(Thread):
-    '''Background thread for downloading & installing JDK into Thonny's folder.
-
-    - Removes any preexisting JDK folders matching the expected version.
-    - Downloads and extracts the required JDK version.
-    - Renames the downloaded folder to the expected format.
-    - Sets JAVA_HOME both in system environment and Thonny configuration.
-    '''
-    def run(self):
-        '''Download and setup JDK (installs to Thonny's config directory)'''
-        # Delete existing Thonny's JDK subfolders matching jdk-<version##>:
-        self.process_match_jdk_dirs(shutil.rmtree)
-
-        # Download and extract JDK subfolder into Thonny's user folder:
-        jdk.install(_VERSION_JDK, path=THONNY_USER_DIR)
-
-        # Rename extracted Thonny's JDK subfolder to jdk-<version##>:
-        self.process_match_jdk_dirs(self.rename_folder, True)
-
-        set_java_home(_JDK_HOME) # Add a Thonny's JAVA_HOME entry for it
-
-
-    @staticmethod
-    def process_match_jdk_dirs(action: PathAction, only_1st=False):
-        '''Apply an action to JDK-matching subfolders in Thonny's folder.'''
-        for path in DownloadJDK.get_all_thonny_folder_paths():
-            if path.name.startswith(_JDK_DIR): # Folder name matches <jdk-##> 
-                action(path) # Callback to run on each matching folder path
-                if only_1st: break # Stop at 1st match occurrence
-
-
-    @staticmethod
-    def get_all_thonny_folder_paths() -> Iterator[Path]:
-        '''Find all subfolder paths within Thonny's user folder'''
-        return filter(Path.is_dir, _THONNY_USER_PATH.iterdir())
-
-
-    @staticmethod
-    def rename_folder(path: StrPath):
-        '''Rename a JDK subfolder to the expected jdk-<version##> format.'''
-        rename(path, _JDK_PATH)
-
-
-
 class JdkDialog(ui_utils.CommonDialog):
     '''User-facing dialog prompting install of required JDK for py5 sketches.
 
@@ -198,23 +153,22 @@ class JdkDialog(ui_utils.CommonDialog):
     - Launches a background thread to handle installation tasks.
     - Shows a success message when installation is complete.
     '''
-    _TITLE = tr('Install JDK ' + _VERSION_JDK + ' for py5')
+    _TITLE = tr('Install JDK ' + DOWNLOAD_JDK + ' for py5')
 
-    _PROGRESS = tr(f'Downloading and extracting JDK {_REQUIRE_JDK} ...')
+    _PROGRESS = tr('Downloading and extracting JDK ' + DOWNLOAD_JDK + ' ...')
 
     _OK, _CANCEL, _DONE = map(tr, ('Proceed', 'Cancel', 'JDK done'))
 
-    _MSG = 'JDK ' + _VERSION_JDK + tr(' extracted to ') + THONNY_USER_DIR + tr(
+    _MSG = 'JDK ' + DOWNLOAD_JDK + tr(' extracted to ') + THONNY_USER_DIR + tr(
         '\n\nYou can now run py5 sketches.')
 
     _INSTALL_JDK = tr(
-        "Thonny requires JDK " + _VERSION_JDK + " to run py5 sketches. "
-        "It'll need to download about 180 MB."
-    )
+        "Thonny requires at least JDK " + VERSION_JDK + " to run py5 sketches. "
+        "It'll need to download about 180 MB.")
 
     _PAD = 0, 15
 
-    def __init__(self, master=workbench, skip_diag_attribs=False, **kw):
+    def __init__(self, master=WORKBENCH, skip_diag_attribs=False, **kw):
         super().__init__(master, skip_diag_attribs, **kw)
 
         # Window/Frame:
@@ -233,35 +187,31 @@ class JdkDialog(ui_utils.CommonDialog):
 
         # OK button:
         self.ok_button = ttk.Button(
-          self.main_frame,
-          text=self._OK,
-          command=self._proceed,
-          default=tk.ACTIVE
-        )
+            self.main_frame,
+            text=self._OK,
+            command=self._proceed,
+            default=tk.ACTIVE)
 
         self.ok_button.grid(
             row=2, column=0,
             padx=15, pady=15,
-            sticky=tk.W
-        )
+            sticky=tk.W)
 
         self.ok_button.focus_set()
 
         # Cancel button:
         self.cancel_button = ttk.Button(
-          self.main_frame,
-          text=self._CANCEL,
-          command=self._close
-        )
+            self.main_frame,
+            text=self._CANCEL,
+            command=self._close)
 
         self.cancel_button.grid(
             row=2, column=1,
             padx=15, pady=15,
-            sticky=tk.E
-        )
+            sticky=tk.E)
 
 
-    def _proceed(self):
+    def _proceed(self) -> None:
         '''Starts JDK downloader thread.'''
         # Get rid of both OK & Cancel buttons:
         if self.ok_button: self.ok_button.destroy()
@@ -277,8 +227,7 @@ class JdkDialog(ui_utils.CommonDialog):
         progress_bar.grid(
             row=2, column=0, columnspan=2,
             padx=15, pady=self._PAD,
-            sticky=tk.EW
-        )
+            sticky=tk.EW)
 
         # Start progress bar animation and download thread:
         if self.main_frame: self.main_frame.tkraise()
@@ -290,7 +239,7 @@ class JdkDialog(ui_utils.CommonDialog):
         self._monitor(download_thread, progress_bar)
 
 
-    def _monitor(self, download: Thread, progress: ttk.Progressbar):
+    def _monitor(self, download: Thread, progress: ttk.Progressbar) -> None:
         '''Animate progress bar while JDK installs and extracts.'''
         if download.is_alive():
             self.after(100, lambda: self._monitor(download, progress))
@@ -299,10 +248,54 @@ class JdkDialog(ui_utils.CommonDialog):
         progress.stop()
         self._close()
 
-        showinfo(self._DONE, self._MSG, parent=workbench)
+        showinfo(self._DONE, self._MSG, parent=WORKBENCH)
 
 
-    def _close(self):
+    def _close(self) -> None:
         '''Fully shutdown the JdkDialog instance.'''
         self.destroy()
         self.main_frame = self.ok_button = self.cancel_button = None
+
+
+
+class DownloadJDK(Thread):
+    '''Background thread for downloading & installing JDK into Thonny's folder.
+
+    - Removes any preexisting JDK folders matching the expected version.
+    - Downloads and extracts the required JDK version.
+    - Renames the downloaded folder to the expected format.
+    - Sets JAVA_HOME both in system environment and Thonny configuration.
+    '''
+    def run(self) -> None:
+        '''Download and setup JDK (installs to Thonny's config directory)'''
+        # Delete existing Thonny's JDK subfolders matching jdk-<version##>:
+        self.process_matchjdk_dirs(shutil.rmtree)
+
+        # Download and extract JDK subfolder into Thonny's user folder:
+        jdk.install(DOWNLOAD_JDK, path=THONNY_USER_DIR)
+
+        # Rename extracted Thonny's JDK subfolder to jdk-<version##>:
+        self.process_matchjdk_dirs(self.rename_folder, True)
+
+        set_java_home(JDK_HOME) # Add a Thonny's JAVA_HOME entry for it
+
+
+    @staticmethod
+    def process_matchjdk_dirs(action: PathAction, only_1st=False) -> None:
+        '''Apply an action to JDK-matching subfolders in Thonny's folder.'''
+        for path in DownloadJDK.get_all_thonny_folder_paths():
+            if path.name.startswith(JDK_DIR): # Folder name matches <jdk-##> 
+                action(path) # Callback to run on each matching folder path
+                if only_1st: break # Stop at 1st match occurrence
+
+
+    @staticmethod
+    def get_all_thonny_folder_paths() -> Iterator[Path]:
+        '''Find all subfolder paths within Thonny's user folder'''
+        return filter(Path.is_dir, THONNY_USER_PATH.iterdir())
+
+
+    @staticmethod
+    def rename_folder(path: StrPath) -> None:
+        '''Rename a JDK subfolder to the expected jdk-<version##> format.'''
+        rename(path, JDK_PATH)

--- a/thonnycontrib/thonny-py5mode/install_jdk.py
+++ b/thonnycontrib/thonny-py5mode/install_jdk.py
@@ -91,7 +91,7 @@ def get_thonny_jdk_install() -> PurePath | Literal['']:
         # Use regexp to check if subfolder contains a valid JDK name: 
         if match := JDK_PATTERN.search(subfolder):
             # Check JDK major version from 1st match group:
-            if is_valid_jdk_version(match.group(1)):
+            if is_valid_jdk_version( match.group(1) ):
                 # Create a full path by joining THONNY_USER_DIR + folder name:
                 jdk_path = adjust_jdk_path(THONNY_USER_PATH / subfolder)
 

--- a/thonnycontrib/thonny-py5mode/install_jdk.py
+++ b/thonnycontrib/thonny-py5mode/install_jdk.py
@@ -108,7 +108,7 @@ def set_java_home(jdk_path: StrPath) -> None:
     env['JAVA_HOME'] = jdk_path # Python's process points to Thonny's JDK too
 
     java_home_entry = create_java_home_entry_from_path(jdk_path)
-    env_vars: set[str] = set(WORKBENCH.get_option('general.environment'))
+    env_vars = dict.fromkeys(WORKBENCH.get_option('general.environment'))
 
     if java_home_entry not in env_vars:
         entries = [ *drop_all_java_home_entries(env_vars), java_home_entry ]

--- a/thonnycontrib/thonny-py5mode/install_jdk.py
+++ b/thonnycontrib/thonny-py5mode/install_jdk.py
@@ -47,9 +47,6 @@ THONNY_USER_PATH = Path(THONNY_USER_DIR)
 JDK_PATH = THONNY_USER_PATH / JDK_DIR
 '''Path for JDK installation subfolder.'''
 
-JDK_HOME = str(JDK_PATH)
-'''JDK install subfolder's full path string.'''
-
 WORKBENCH = get_workbench()
 '''Thonny's workbench singleton instance.'''
 
@@ -88,14 +85,14 @@ def get_thonny_jdk_install() -> PurePath | Literal['']:
     and return its path. Otherwise, return an empty string.'''
 
     for subfolder in get_all_thonny_folders(): # Loop over each subfolder name
-        # Use regexp to check if subfolder contains a valid JDK name:
+        # Use regexp to check if subfolder contains a valid JDK name: 
         if match := JDK_PATTERN.search(subfolder):
             # Check JDK major version from 1st match group:
-            if is_valid_jdk_version(match.group(1)):
+            if is_valid_jdk_version( match.group(1) ):
                 # Create a full path by joining THONNY_USER_DIR + folder name:
                 jdk_path = adjust_jdk_path(THONNY_USER_PATH / subfolder)
 
-                # Check and return a valid JDK subfolder in THONNY_USER_DIR:
+                # Check and return a valid JDK subfolder from THONNY_USER_DIR:
                 if is_valid_jdk_path(jdk_path): return jdk_path
 
     return '' # No JDK with required version found in THONNY_USER_DIR
@@ -108,7 +105,7 @@ def set_java_home(jdk_path: StrPath) -> None:
     env['JAVA_HOME'] = jdk_path # Python's process points to Thonny's JDK too
 
     java_home_entry = create_java_home_entry_from_path(jdk_path)
-    env_vars: set[str] = set(WORKBENCH.get_option('general.environment'))
+    env_vars = dict.fromkeys(WORKBENCH.get_option('general.environment'))
 
     if java_home_entry not in env_vars:
         entries = [ *drop_all_java_home_entries(env_vars), java_home_entry ]
@@ -288,7 +285,7 @@ class DownloadJDK(Thread):
         # Rename extracted Thonny's JDK subfolder to jdk-<version##>:
         self.process_match_jdk_dirs(self.rename_folder, True)
 
-        set_java_home(JDK_HOME) # Add a Thonny's JAVA_HOME entry for it
+        set_java_home(JDK_PATH) # Add a Thonny's JAVA_HOME entry for it
 
 
     @staticmethod
@@ -296,7 +293,7 @@ class DownloadJDK(Thread):
         '''Apply an action to JDK-matching subfolders in Thonny's folder.'''
 
         for path in DownloadJDK.get_all_thonny_folder_paths():
-            if path.name.startswith(JDK_DIR): # Folder name matches <jdk-##>
+            if path.name.startswith(JDK_DIR): # Folder name matches <jdk-##> 
                 action(path) # Callback to run on each matching folder path
                 if only_1st: break # Stop at 1st match occurrence
 

--- a/thonnycontrib/thonny-py5mode/install_jdk.py
+++ b/thonnycontrib/thonny-py5mode/install_jdk.py
@@ -1,10 +1,7 @@
-'''thonny-py5mode JDK installer
-   checks for JDK and, if not found, installs it to the Thonny config directory
-'''
+'''thonny-py5mode JDK installer.
+Checks for JDK and, if not found, installs it to Thonny's user directory.'''
 
-import re
-import shutil
-import jdk
+import re, shutil, jdk
 
 from pathlib import Path, PurePath
 from threading import Thread
@@ -12,7 +9,7 @@ from threading import Thread
 from os import environ as env, scandir, rename, PathLike
 from os.path import islink, realpath
 
-from typing import Callable, Literal, TypeAlias
+from typing import Any, Callable, Literal, TypeAlias
 from collections.abc import Iterable, Iterator
 
 import tkinter as tk
@@ -25,44 +22,59 @@ from thonny.languages import tr
 StrPath: TypeAlias = str | PathLike[str]
 '''A type representing string-based filesystem paths.'''
 
-PathAction: TypeAlias = Callable[[StrPath], None]
+PathAction: TypeAlias = Callable[[StrPath], Any]
 '''Represents an action applied to a single path-like object.'''
 
-_JDK_PATTERN = re.compile(r"""
+JDK_PATTERN = re.compile(r"""
     (?:java|jdk)    # Match 'java' or 'jdk' (non-capturing group)
     -?              # Match optional hyphen '-'
     (\d+)           # Capture JDK major version number as group(1)
 """, re.IGNORECASE | re.VERBOSE)
+'''Captures the major version number from strings like "java-17" or "jdk21".'''
 
-_REQUIRE_JDK, _VERSION_JDK = 17, '17' # Minimum required version
-_JDK_DIR = 'jdk-' + _VERSION_JDK # JDK subfolder name
+REQUIRE_JDK, VERSION_JDK = 17, '17'
+'''JDK minimum required version to run Processing.'''
 
-_THONNY_USER_PATH = Path(THONNY_USER_DIR) # Thonny folder's full path string
-_JDK_PATH = _THONNY_USER_PATH / _JDK_DIR # Path for JDK subfolder
-_JDK_HOME = str(_JDK_PATH) # JDK subfolder's full path string
+DOWNLOAD_JDK = '21'
+'''JDK version to download.'''
 
-workbench = get_workbench() # Workbench singleton instance
+JDK_DIR = 'jdk-' + DOWNLOAD_JDK
+'''JDK install subfolder name.'''
 
-def install_jdk(): # Module's main entry-point function
+THONNY_USER_PATH = Path(THONNY_USER_DIR)
+'''Thonny user folder's full path string.'''
+
+JDK_PATH = THONNY_USER_PATH / JDK_DIR
+'''Path for JDK installation subfolder.'''
+
+JDK_HOME = str(JDK_PATH)
+'''JDK install subfolder's full path string.'''
+
+WORKBENCH = get_workbench()
+'''Thonny's workbench singleton instance.'''
+
+def install_jdk() -> None: # Module's main entry-point function
     '''Call this function from where this module is imported.'''
-    if is_java_home_set(): return # JAVA_HOME points to a required JDK version
+
+    if is_java_home_set(): return # JAVA_HOME already points to required version
 
     # Set a local JAVA_HOME to the detected JDK found in THONNY_USER_DIR:
     if path := get_thonny_jdk_install(): set_java_home(path)
 
     # Otherwise, if Thonny doesn't have a proper JDK version...
-    else: ui_utils.show_dialog(JdkDialog()) # ... ask permission to download it.
+    else: ui_utils.show_dialog(JdkDialog()) # ... ask permission to download 1.
 
 
 def is_java_home_set() -> bool:
     '''Check system for existing JDK that meets the py5 version requirements.'''
+
     if java_home := env.get('JAVA_HOME'): # Check if JAVA_HOME is already set
         system_jdk = 'TBD' # JDK version To-Be-Determined
 
         if islink(java_home):
             java_home = realpath(java_home) # If symlink, resolve actual path
 
-        if match := _JDK_PATTERN.search(java_home):
+        if match := JDK_PATTERN.search(java_home):
             system_jdk = match.group(1) # Get JDK version from 1st match group
 
         if is_valid_jdk_version(system_jdk) and is_valid_jdk_path(java_home):
@@ -74,13 +86,14 @@ def is_java_home_set() -> bool:
 def get_thonny_jdk_install() -> PurePath | Literal['']:
     '''Check Thonny's user folder for a JDK installation subfolder
     and return its path. Otherwise, return an empty string.'''
+
     for subfolder in get_all_thonny_folders(): # Loop over each subfolder name
-        # Use regexp to check if subfolder contains a valid JDK name: 
-        if match := _JDK_PATTERN.search(subfolder):
+        # Use regexp to check if subfolder contains a valid JDK name:
+        if match := JDK_PATTERN.search(subfolder):
             # Check JDK major version from 1st match group:
             if is_valid_jdk_version(match.group(1)):
                 # Create a full path by joining THONNY_USER_DIR + folder name:
-                jdk_path = adjust_jdk_path(_THONNY_USER_PATH / subfolder)
+                jdk_path = adjust_jdk_path(THONNY_USER_PATH / subfolder)
 
                 # Check and return a valid JDK subfolder in THONNY_USER_DIR:
                 if is_valid_jdk_path(jdk_path): return jdk_path
@@ -88,27 +101,28 @@ def get_thonny_jdk_install() -> PurePath | Literal['']:
     return '' # No JDK with required version found in THONNY_USER_DIR
 
 
-def set_java_home(jdk_path: StrPath):
+def set_java_home(jdk_path: StrPath) -> None:
     '''Add JDK path to config file (tools > options > general > env vars).'''
-    jdk_path = str(adjust_jdk_path(jdk_path))
-    env['JAVA_HOME'] = jdk_path # Python's process points to Thonny's JDK
 
-    jdk_path_entry = create_java_home_entry_from_path(jdk_path)
-    env_vars: set[str] = set(workbench.get_option('general.environment'))
+    jdk_path = str(adjust_jdk_path(jdk_path)) # Platform-adjusted path
+    env['JAVA_HOME'] = jdk_path # Python's process points to Thonny's JDK too
 
-    if jdk_path_entry not in env_vars:
-        entries = [*drop_all_java_home_entries(env_vars)]
-        entries.append(jdk_path_entry)
-        workbench.set_option('general.environment', entries)
-        showinfo('JAVA_HOME', jdk_path, parent=workbench)
+    java_home_entry = create_java_home_entry_from_path(jdk_path)
+    env_vars: set[str] = set(WORKBENCH.get_option('general.environment'))
+
+    if java_home_entry not in env_vars:
+        entries = [ *drop_all_java_home_entries(env_vars), java_home_entry ]
+        WORKBENCH.set_option('general.environment', entries)
+        showinfo('JAVA_HOME', jdk_path, parent=WORKBENCH)
 
 
 def adjust_jdk_path(jdk_path: StrPath) -> PurePath:
     '''Adjust JDK path for the specificity of current platform.'''
+
     jdk_path = PurePath(jdk_path)
 
     # if MacOS, append "/Contents/Home/" to form the actual JDK path for it:
-    if jdk.OS is jdk.OperatingSystem.MAC and jdk_path.parts[-1] != 'Home':
+    if jdk.OS is jdk.OperatingSystem.MAC and jdk_path.name != 'Home':
         jdk_path = jdk_path / 'Contents' / 'Home'
 
     return jdk_path
@@ -131,7 +145,7 @@ def _non_java_home_predicate(entry: str) -> bool:
 
 def is_valid_jdk_version(jdk_version: str) -> bool:
     '''Check if JDK version meets minimum version requirement.'''
-    return jdk_version.isdigit() and int(jdk_version) >= _REQUIRE_JDK
+    return jdk_version.isdigit() and int(jdk_version) >= REQUIRE_JDK
 
 
 def is_valid_jdk_path(jdk_path: StrPath) -> bool:
@@ -146,141 +160,85 @@ def get_all_thonny_folders() -> list[str]:
         return sorted((e.name for e in entries if e.is_dir()), reverse=True)
 
 
-class DownloadJDK(Thread):
-    '''Background thread for downloading & installing JDK into Thonny's folder.
-
-    - Removes any preexisting JDK folders matching the expected version.
-    - Downloads and extracts the required JDK version.
-    - Renames the downloaded folder to the expected format.
-    - Sets JAVA_HOME both in system environment and Thonny configuration.
-    '''
-    def run(self):
-        '''Download and setup JDK (installs to Thonny's config directory)'''
-        # Delete existing Thonny's JDK subfolders matching jdk-<version##>:
-        self.process_match_jdk_dirs(shutil.rmtree)
-
-        # Download and extract JDK subfolder into Thonny's user folder:
-        jdk.install(_VERSION_JDK, path=THONNY_USER_DIR)
-
-        # Rename extracted Thonny's JDK subfolder to jdk-<version##>:
-        self.process_match_jdk_dirs(self.rename_folder, True)
-
-        set_java_home(_JDK_HOME) # Add a Thonny's JAVA_HOME entry for it
-
-
-    @staticmethod
-    def process_match_jdk_dirs(action: PathAction, only_1st=False):
-        '''Apply an action to JDK-matching subfolders in Thonny's folder.'''
-        for path in DownloadJDK.get_all_thonny_folder_paths():
-            if path.name.startswith(_JDK_DIR): # Folder name matches <jdk-##> 
-                action(path) # Callback to run on each matching folder path
-                if only_1st: break # Stop at 1st match occurrence
-
-
-    @staticmethod
-    def get_all_thonny_folder_paths() -> Iterator[Path]:
-        '''Find all subfolder paths within Thonny's user folder'''
-        return filter(Path.is_dir, _THONNY_USER_PATH.iterdir())
-
-
-    @staticmethod
-    def rename_folder(path: StrPath):
-        '''Rename a JDK subfolder to the expected jdk-<version##> format.'''
-        rename(path, _JDK_PATH)
-
-
-
 class JdkDialog(ui_utils.CommonDialog):
     '''User-facing dialog prompting install of required JDK for py5 sketches.
-
     - Presents user with option to proceed or cancel the JDK installation.
     - Displays a horizontal indeterminate-sized progress bar during download.
     - Launches a background thread to handle installation tasks.
-    - Shows a success message when installation is complete.
-    '''
-    _TITLE = tr('Install JDK ' + _VERSION_JDK + ' for py5')
+    - Shows a success message when installation is complete.'''
 
-    _PROGRESS = tr(f'Downloading and extracting JDK {_REQUIRE_JDK} ...')
+    _TITLE = tr('Install JDK ' + DOWNLOAD_JDK + ' for py5')
+
+    _PROGRESS = tr('Downloading and extracting JDK ' + DOWNLOAD_JDK + ' ...')
 
     _OK, _CANCEL, _DONE = map(tr, ('Proceed', 'Cancel', 'JDK done'))
 
-    _MSG = 'JDK ' + _VERSION_JDK + tr(' extracted to ') + THONNY_USER_DIR + tr(
+    _MSG = 'JDK ' + DOWNLOAD_JDK + tr(' extracted to ') + THONNY_USER_DIR + tr(
         '\n\nYou can now run py5 sketches.')
 
     _INSTALL_JDK = tr(
-        "Thonny requires JDK " + _VERSION_JDK + " to run py5 sketches. "
-        "It'll need to download about 180 MB."
-    )
+        "Thonny requires at least JDK " + VERSION_JDK + " to run py5 sketches. "
+        "It'll need to download about 180 MB.")
 
-    _PAD = 0, 15
+    _PROGRESS_BAR_Y_PADDING = 0, 15
 
-    def __init__(self, master=workbench, skip_diag_attribs=False, **kw):
+    def __init__(self, master=WORKBENCH, skip_diag_attribs=False, **kw):
         super().__init__(master, skip_diag_attribs, **kw)
 
-        # Window/Frame:
-        self.main_frame = ttk.Frame(self)
-        self.main_frame.grid(ipadx=15, ipady=15, sticky=tk.NSEW)
-        self.main_frame.rowconfigure(0, weight=1)
-        self.main_frame.columnconfigure(0, weight=1)
+        # Set dialog properties: title, fixed size, close button disabled:
+        self.title(self._TITLE) # Dialog title for JDK installation
+        self.resizable(height=tk.FALSE, width=tk.FALSE) # Prevent its resizing
+        self.protocol('WM_DELETE_WINDOW', '{#}') # Disable its close button
 
-        self.title(self._TITLE)
-        self.resizable(height=tk.FALSE, width=tk.FALSE)
-        self.protocol('WM_DELETE_WINDOW', '{#}') # Block window close button
+        # Window/Frame:
+        main_frame = self.main_frame = ttk.Frame(self)
+        main_frame.grid(ipadx=15, ipady=15, sticky=tk.NSEW)
+        main_frame.rowconfigure(0, weight=1)
+        main_frame.columnconfigure(0, weight=1)
 
         # Display install message:
-        message_label = ttk.Label(self.main_frame, text=self._INSTALL_JDK)
+        message_label = ttk.Label(main_frame, text=self._INSTALL_JDK)
         message_label.grid(pady=0, columnspan=2)
 
-        # OK button:
-        self.ok_button = ttk.Button(
-          self.main_frame,
-          text=self._OK,
-          command=self._proceed,
-          default=tk.ACTIVE
-        )
+        # OK proceed button:
+        ok_button = self.ok_button = ttk.Button(
+            main_frame,
+            text=self._OK,
+            command=self._proceed,
+            default=tk.ACTIVE)
 
-        self.ok_button.grid(
-            row=2, column=0,
-            padx=15, pady=15,
-            sticky=tk.W
-        )
-
-        self.ok_button.focus_set()
+        ok_button.grid(row=2, column=0, padx=15, pady=15, sticky=tk.W)
+        ok_button.focus_set()
 
         # Cancel button:
-        self.cancel_button = ttk.Button(
-          self.main_frame,
-          text=self._CANCEL,
-          command=self._close
-        )
+        cancel_button = self.cancel_button = ttk.Button(
+            main_frame,
+            text=self._CANCEL,
+            command=self._close)
 
-        self.cancel_button.grid(
-            row=2, column=1,
-            padx=15, pady=15,
-            sticky=tk.E
-        )
+        cancel_button.grid(row=2, column=1, padx=15, pady=15, sticky=tk.E)
 
 
-    def _proceed(self):
+    def _proceed(self) -> None:
         '''Starts JDK downloader thread.'''
+
         # Get rid of both OK & Cancel buttons:
         if self.ok_button: self.ok_button.destroy()
         if self.cancel_button: self.cancel_button.destroy()
 
         # Progress bar label:
         dl_label = ttk.Label(self.main_frame, text=self._PROGRESS)
-        dl_label.grid(row=1, columnspan=2, pady=self._PAD)
+        dl_label.grid(row=1, columnspan=2, pady=self._PROGRESS_BAR_Y_PADDING)
 
         # Progress bar:
         progress_bar = ttk.Progressbar(self.main_frame, mode='indeterminate')
 
         progress_bar.grid(
             row=2, column=0, columnspan=2,
-            padx=15, pady=self._PAD,
-            sticky=tk.EW
-        )
+            padx=15, pady=self._PROGRESS_BAR_Y_PADDING,
+            sticky=tk.EW)
 
-        # Start progress bar animation and download thread:
+        # Start progress bar animation + download thread:
         if self.main_frame: self.main_frame.tkraise()
 
         download_thread = DownloadJDK()
@@ -290,19 +248,66 @@ class JdkDialog(ui_utils.CommonDialog):
         self._monitor(download_thread, progress_bar)
 
 
-    def _monitor(self, download: Thread, progress: ttk.Progressbar):
+    def _monitor(self, download: Thread, progress: ttk.Progressbar) -> None:
         '''Animate progress bar while JDK installs and extracts.'''
+
         if download.is_alive():
             self.after(100, lambda: self._monitor(download, progress))
             return
 
+        # Destroy this JDK dialog instance once download has finished:
         progress.stop()
         self._close()
 
-        showinfo(self._DONE, self._MSG, parent=workbench)
+        showinfo(self._DONE, self._MSG, parent=WORKBENCH)
 
 
-    def _close(self):
+    def _close(self) -> None:
         '''Fully shutdown the JdkDialog instance.'''
         self.destroy()
         self.main_frame = self.ok_button = self.cancel_button = None
+
+
+
+class DownloadJDK(Thread):
+    '''Background thread for downloading & installing JDK into Thonny's folder.
+    - Removes any preexisting JDK folders matching the expected version.
+    - Downloads and extracts the required JDK version.
+    - Renames the downloaded folder to the expected format.
+    - Sets JAVA_HOME on Thonny configuration.'''
+
+    def run(self) -> None:
+        '''Download and setup JDK (installs to Thonny's user directory)'''
+
+        # Delete existing Thonny's JDK subfolders matching jdk-<version##>:
+        self.process_match_jdk_dirs(shutil.rmtree)
+
+        # Download and extract JDK subfolder into Thonny's user folder:
+        jdk.install(DOWNLOAD_JDK, path=THONNY_USER_DIR)
+
+        # Rename extracted Thonny's JDK subfolder to jdk-<version##>:
+        self.process_match_jdk_dirs(self.rename_folder, True)
+
+        set_java_home(JDK_HOME) # Add a Thonny's JAVA_HOME entry for it
+
+
+    @staticmethod
+    def process_match_jdk_dirs(action: PathAction, only_1st=False) -> None:
+        '''Apply an action to JDK-matching subfolders in Thonny's folder.'''
+
+        for path in DownloadJDK.get_all_thonny_folder_paths():
+            if path.name.startswith(JDK_DIR): # Folder name matches <jdk-##>
+                action(path) # Callback to run on each matching folder path
+                if only_1st: break # Stop at 1st match occurrence
+
+
+    @staticmethod
+    def get_all_thonny_folder_paths() -> Iterator[Path]:
+        '''Find all subfolder paths within Thonny's user folder'''
+        return filter(Path.is_dir, THONNY_USER_PATH.iterdir())
+
+
+    @staticmethod
+    def rename_folder(path: StrPath) -> None:
+        '''Rename a JDK subfolder to the expected jdk-<version##> format.'''
+        rename(path, JDK_PATH)

--- a/thonnycontrib/thonny-py5mode/install_jdk.py
+++ b/thonnycontrib/thonny-py5mode/install_jdk.py
@@ -1,7 +1,10 @@
-'''thonny-py5mode JDK installer.
-Checks for JDK and, if not found, installs it to Thonny's user directory.'''
+'''thonny-py5mode JDK installer
+   checks for JDK and, if not found, installs it to the Thonny config directory
+'''
 
-import re, shutil, jdk
+import re
+import shutil
+import jdk
 
 from pathlib import Path, PurePath
 from threading import Thread
@@ -9,7 +12,7 @@ from threading import Thread
 from os import environ as env, scandir, rename, PathLike
 from os.path import islink, realpath
 
-from typing import Any, Callable, Literal, TypeAlias
+from typing import Callable, Literal, TypeAlias
 from collections.abc import Iterable, Iterator
 
 import tkinter as tk
@@ -22,56 +25,44 @@ from thonny.languages import tr
 StrPath: TypeAlias = str | PathLike[str]
 '''A type representing string-based filesystem paths.'''
 
-PathAction: TypeAlias = Callable[[StrPath], Any]
+PathAction: TypeAlias = Callable[[StrPath], None]
 '''Represents an action applied to a single path-like object.'''
 
-JDK_PATTERN = re.compile(r"""
+_JDK_PATTERN = re.compile(r"""
     (?:java|jdk)    # Match 'java' or 'jdk' (non-capturing group)
     -?              # Match optional hyphen '-'
     (\d+)           # Capture JDK major version number as group(1)
 """, re.IGNORECASE | re.VERBOSE)
-'''Captures the major version number from strings like "java-17" or "jdk21".'''
 
-REQUIRE_JDK, VERSION_JDK = 17, '17'
-'''JDK minimum required version to run Processing.'''
+_REQUIRE_JDK, _VERSION_JDK = 17, '17' # Minimum required version
+_JDK_DIR = 'jdk-' + _VERSION_JDK # JDK subfolder name
 
-DOWNLOAD_JDK = '21'
-'''JDK version to download.'''
+_THONNY_USER_PATH = Path(THONNY_USER_DIR) # Thonny folder's full path string
+_JDK_PATH = _THONNY_USER_PATH / _JDK_DIR # Path for JDK subfolder
+_JDK_HOME = str(_JDK_PATH) # JDK subfolder's full path string
 
-JDK_DIR = 'jdk-' + DOWNLOAD_JDK
-'''JDK install subfolder name.'''
+workbench = get_workbench() # Workbench singleton instance
 
-THONNY_USER_PATH = Path(THONNY_USER_DIR)
-'''Thonny user folder's full path string.'''
-
-JDK_PATH = THONNY_USER_PATH / JDK_DIR
-'''Path for JDK installation subfolder.'''
-
-WORKBENCH = get_workbench()
-'''Thonny's workbench singleton instance.'''
-
-def install_jdk() -> None: # Module's main entry-point function
+def install_jdk(): # Module's main entry-point function
     '''Call this function from where this module is imported.'''
-
-    if is_java_home_set(): return # JAVA_HOME already points to required version
+    if is_java_home_set(): return # JAVA_HOME points to a required JDK version
 
     # Set a local JAVA_HOME to the detected JDK found in THONNY_USER_DIR:
     if path := get_thonny_jdk_install(): set_java_home(path)
 
     # Otherwise, if Thonny doesn't have a proper JDK version...
-    else: ui_utils.show_dialog(JdkDialog()) # ... ask permission to download 1.
+    else: ui_utils.show_dialog(JdkDialog()) # ... ask permission to download it.
 
 
 def is_java_home_set() -> bool:
     '''Check system for existing JDK that meets the py5 version requirements.'''
-
     if java_home := env.get('JAVA_HOME'): # Check if JAVA_HOME is already set
         system_jdk = 'TBD' # JDK version To-Be-Determined
 
         if islink(java_home):
             java_home = realpath(java_home) # If symlink, resolve actual path
 
-        if match := JDK_PATTERN.search(java_home):
+        if match := _JDK_PATTERN.search(java_home):
             system_jdk = match.group(1) # Get JDK version from 1st match group
 
         if is_valid_jdk_version(system_jdk) and is_valid_jdk_path(java_home):
@@ -83,43 +74,41 @@ def is_java_home_set() -> bool:
 def get_thonny_jdk_install() -> PurePath | Literal['']:
     '''Check Thonny's user folder for a JDK installation subfolder
     and return its path. Otherwise, return an empty string.'''
-
     for subfolder in get_all_thonny_folders(): # Loop over each subfolder name
         # Use regexp to check if subfolder contains a valid JDK name: 
-        if match := JDK_PATTERN.search(subfolder):
+        if match := _JDK_PATTERN.search(subfolder):
             # Check JDK major version from 1st match group:
-            if is_valid_jdk_version( match.group(1) ):
+            if is_valid_jdk_version(match.group(1)):
                 # Create a full path by joining THONNY_USER_DIR + folder name:
-                jdk_path = adjust_jdk_path(THONNY_USER_PATH / subfolder)
+                jdk_path = adjust_jdk_path(_THONNY_USER_PATH / subfolder)
 
-                # Check and return a valid JDK subfolder from THONNY_USER_DIR:
+                # Check and return a valid JDK subfolder in THONNY_USER_DIR:
                 if is_valid_jdk_path(jdk_path): return jdk_path
 
     return '' # No JDK with required version found in THONNY_USER_DIR
 
 
-def set_java_home(jdk_path: StrPath) -> None:
+def set_java_home(jdk_path: StrPath):
     '''Add JDK path to config file (tools > options > general > env vars).'''
+    jdk_path = str(adjust_jdk_path(jdk_path))
+    env['JAVA_HOME'] = jdk_path # Python's process points to Thonny's JDK
 
-    jdk_path = str(adjust_jdk_path(jdk_path)) # Platform-adjusted path
-    env['JAVA_HOME'] = jdk_path # Python's process points to Thonny's JDK too
+    jdk_path_entry = create_java_home_entry_from_path(jdk_path)
+    env_vars: set[str] = set(workbench.get_option('general.environment'))
 
-    java_home_entry = create_java_home_entry_from_path(jdk_path)
-    env_vars = dict.fromkeys(WORKBENCH.get_option('general.environment'))
-
-    if java_home_entry not in env_vars:
-        entries = [ *drop_all_java_home_entries(env_vars), java_home_entry ]
-        WORKBENCH.set_option('general.environment', entries)
-        showinfo('JAVA_HOME', jdk_path, parent=WORKBENCH)
+    if jdk_path_entry not in env_vars:
+        entries = [*drop_all_java_home_entries(env_vars)]
+        entries.append(jdk_path_entry)
+        workbench.set_option('general.environment', entries)
+        showinfo('JAVA_HOME', jdk_path, parent=workbench)
 
 
 def adjust_jdk_path(jdk_path: StrPath) -> PurePath:
     '''Adjust JDK path for the specificity of current platform.'''
-
     jdk_path = PurePath(jdk_path)
 
     # if MacOS, append "/Contents/Home/" to form the actual JDK path for it:
-    if jdk.OS is jdk.OperatingSystem.MAC and jdk_path.name != 'Home':
+    if jdk.OS is jdk.OperatingSystem.MAC and jdk_path.parts[-1] != 'Home':
         jdk_path = jdk_path / 'Contents' / 'Home'
 
     return jdk_path
@@ -142,7 +131,7 @@ def _non_java_home_predicate(entry: str) -> bool:
 
 def is_valid_jdk_version(jdk_version: str) -> bool:
     '''Check if JDK version meets minimum version requirement.'''
-    return jdk_version.isdigit() and int(jdk_version) >= REQUIRE_JDK
+    return jdk_version.isdigit() and int(jdk_version) >= _REQUIRE_JDK
 
 
 def is_valid_jdk_path(jdk_path: StrPath) -> bool:
@@ -157,85 +146,141 @@ def get_all_thonny_folders() -> list[str]:
         return sorted((e.name for e in entries if e.is_dir()), reverse=True)
 
 
+class DownloadJDK(Thread):
+    '''Background thread for downloading & installing JDK into Thonny's folder.
+
+    - Removes any preexisting JDK folders matching the expected version.
+    - Downloads and extracts the required JDK version.
+    - Renames the downloaded folder to the expected format.
+    - Sets JAVA_HOME both in system environment and Thonny configuration.
+    '''
+    def run(self):
+        '''Download and setup JDK (installs to Thonny's config directory)'''
+        # Delete existing Thonny's JDK subfolders matching jdk-<version##>:
+        self.process_match_jdk_dirs(shutil.rmtree)
+
+        # Download and extract JDK subfolder into Thonny's user folder:
+        jdk.install(_VERSION_JDK, path=THONNY_USER_DIR)
+
+        # Rename extracted Thonny's JDK subfolder to jdk-<version##>:
+        self.process_match_jdk_dirs(self.rename_folder, True)
+
+        set_java_home(_JDK_HOME) # Add a Thonny's JAVA_HOME entry for it
+
+
+    @staticmethod
+    def process_match_jdk_dirs(action: PathAction, only_1st=False):
+        '''Apply an action to JDK-matching subfolders in Thonny's folder.'''
+        for path in DownloadJDK.get_all_thonny_folder_paths():
+            if path.name.startswith(_JDK_DIR): # Folder name matches <jdk-##> 
+                action(path) # Callback to run on each matching folder path
+                if only_1st: break # Stop at 1st match occurrence
+
+
+    @staticmethod
+    def get_all_thonny_folder_paths() -> Iterator[Path]:
+        '''Find all subfolder paths within Thonny's user folder'''
+        return filter(Path.is_dir, _THONNY_USER_PATH.iterdir())
+
+
+    @staticmethod
+    def rename_folder(path: StrPath):
+        '''Rename a JDK subfolder to the expected jdk-<version##> format.'''
+        rename(path, _JDK_PATH)
+
+
+
 class JdkDialog(ui_utils.CommonDialog):
     '''User-facing dialog prompting install of required JDK for py5 sketches.
+
     - Presents user with option to proceed or cancel the JDK installation.
     - Displays a horizontal indeterminate-sized progress bar during download.
     - Launches a background thread to handle installation tasks.
-    - Shows a success message when installation is complete.'''
+    - Shows a success message when installation is complete.
+    '''
+    _TITLE = tr('Install JDK ' + _VERSION_JDK + ' for py5')
 
-    _TITLE = tr('Install JDK ' + DOWNLOAD_JDK + ' for py5')
-
-    _PROGRESS = tr('Downloading and extracting JDK ' + DOWNLOAD_JDK + ' ...')
+    _PROGRESS = tr(f'Downloading and extracting JDK {_REQUIRE_JDK} ...')
 
     _OK, _CANCEL, _DONE = map(tr, ('Proceed', 'Cancel', 'JDK done'))
 
-    _MSG = 'JDK ' + DOWNLOAD_JDK + tr(' extracted to ') + THONNY_USER_DIR + tr(
+    _MSG = 'JDK ' + _VERSION_JDK + tr(' extracted to ') + THONNY_USER_DIR + tr(
         '\n\nYou can now run py5 sketches.')
 
     _INSTALL_JDK = tr(
-        "Thonny requires at least JDK " + VERSION_JDK + " to run py5 sketches. "
-        "It'll need to download about 180 MB.")
+        "Thonny requires JDK " + _VERSION_JDK + " to run py5 sketches. "
+        "It'll need to download about 180 MB."
+    )
 
-    _PROGRESS_BAR_Y_PADDING = 0, 15
+    _PAD = 0, 15
 
-    def __init__(self, master=WORKBENCH, skip_diag_attribs=False, **kw):
+    def __init__(self, master=workbench, skip_diag_attribs=False, **kw):
         super().__init__(master, skip_diag_attribs, **kw)
 
-        # Set dialog properties: title, fixed size, close button disabled:
-        self.title(self._TITLE) # Dialog title for JDK installation
-        self.resizable(height=tk.FALSE, width=tk.FALSE) # Prevent its resizing
-        self.protocol('WM_DELETE_WINDOW', '{#}') # Disable its close button
-
         # Window/Frame:
-        main_frame = self.main_frame = ttk.Frame(self)
-        main_frame.grid(ipadx=15, ipady=15, sticky=tk.NSEW)
-        main_frame.rowconfigure(0, weight=1)
-        main_frame.columnconfigure(0, weight=1)
+        self.main_frame = ttk.Frame(self)
+        self.main_frame.grid(ipadx=15, ipady=15, sticky=tk.NSEW)
+        self.main_frame.rowconfigure(0, weight=1)
+        self.main_frame.columnconfigure(0, weight=1)
+
+        self.title(self._TITLE)
+        self.resizable(height=tk.FALSE, width=tk.FALSE)
+        self.protocol('WM_DELETE_WINDOW', '{#}') # Block window close button
 
         # Display install message:
-        message_label = ttk.Label(main_frame, text=self._INSTALL_JDK)
+        message_label = ttk.Label(self.main_frame, text=self._INSTALL_JDK)
         message_label.grid(pady=0, columnspan=2)
 
-        # OK proceed button:
-        ok_button = self.ok_button = ttk.Button(
-            main_frame,
-            text=self._OK,
-            command=self._proceed,
-            default=tk.ACTIVE)
+        # OK button:
+        self.ok_button = ttk.Button(
+          self.main_frame,
+          text=self._OK,
+          command=self._proceed,
+          default=tk.ACTIVE
+        )
 
-        ok_button.grid(row=2, column=0, padx=15, pady=15, sticky=tk.W)
-        ok_button.focus_set()
+        self.ok_button.grid(
+            row=2, column=0,
+            padx=15, pady=15,
+            sticky=tk.W
+        )
+
+        self.ok_button.focus_set()
 
         # Cancel button:
-        cancel_button = self.cancel_button = ttk.Button(
-            main_frame,
-            text=self._CANCEL,
-            command=self._close)
+        self.cancel_button = ttk.Button(
+          self.main_frame,
+          text=self._CANCEL,
+          command=self._close
+        )
 
-        cancel_button.grid(row=2, column=1, padx=15, pady=15, sticky=tk.E)
+        self.cancel_button.grid(
+            row=2, column=1,
+            padx=15, pady=15,
+            sticky=tk.E
+        )
 
 
-    def _proceed(self) -> None:
+    def _proceed(self):
         '''Starts JDK downloader thread.'''
-
         # Get rid of both OK & Cancel buttons:
         if self.ok_button: self.ok_button.destroy()
         if self.cancel_button: self.cancel_button.destroy()
 
         # Progress bar label:
         dl_label = ttk.Label(self.main_frame, text=self._PROGRESS)
-        dl_label.grid(row=1, columnspan=2, pady=self._PROGRESS_BAR_Y_PADDING)
+        dl_label.grid(row=1, columnspan=2, pady=self._PAD)
 
         # Progress bar:
         progress_bar = ttk.Progressbar(self.main_frame, mode='indeterminate')
 
         progress_bar.grid(
             row=2, column=0, columnspan=2,
-            padx=15, pady=self._PROGRESS_BAR_Y_PADDING,
-            sticky=tk.EW)
+            padx=15, pady=self._PAD,
+            sticky=tk.EW
+        )
 
-        # Start progress bar animation + download thread:
+        # Start progress bar animation and download thread:
         if self.main_frame: self.main_frame.tkraise()
 
         download_thread = DownloadJDK()
@@ -245,66 +290,19 @@ class JdkDialog(ui_utils.CommonDialog):
         self._monitor(download_thread, progress_bar)
 
 
-    def _monitor(self, download: Thread, progress: ttk.Progressbar) -> None:
+    def _monitor(self, download: Thread, progress: ttk.Progressbar):
         '''Animate progress bar while JDK installs and extracts.'''
-
         if download.is_alive():
             self.after(100, lambda: self._monitor(download, progress))
             return
 
-        # Destroy this JDK dialog instance once download has finished:
         progress.stop()
         self._close()
 
-        showinfo(self._DONE, self._MSG, parent=WORKBENCH)
+        showinfo(self._DONE, self._MSG, parent=workbench)
 
 
-    def _close(self) -> None:
+    def _close(self):
         '''Fully shutdown the JdkDialog instance.'''
         self.destroy()
         self.main_frame = self.ok_button = self.cancel_button = None
-
-
-
-class DownloadJDK(Thread):
-    '''Background thread for downloading & installing JDK into Thonny's folder.
-    - Removes any preexisting JDK folders matching the expected version.
-    - Downloads and extracts the required JDK version.
-    - Renames the downloaded folder to the expected format.
-    - Sets JAVA_HOME on Thonny configuration.'''
-
-    def run(self) -> None:
-        '''Download and setup JDK (installs to Thonny's user directory)'''
-
-        # Delete existing Thonny's JDK subfolders matching jdk-<version##>:
-        self.process_match_jdk_dirs(shutil.rmtree)
-
-        # Download and extract JDK subfolder into Thonny's user folder:
-        jdk.install(DOWNLOAD_JDK, path=THONNY_USER_DIR)
-
-        # Rename extracted Thonny's JDK subfolder to jdk-<version##>:
-        self.process_match_jdk_dirs(self.rename_folder, True)
-
-        set_java_home(JDK_PATH) # Add a Thonny's JAVA_HOME entry for it
-
-
-    @staticmethod
-    def process_match_jdk_dirs(action: PathAction, only_1st=False) -> None:
-        '''Apply an action to JDK-matching subfolders in Thonny's folder.'''
-
-        for path in DownloadJDK.get_all_thonny_folder_paths():
-            if path.name.startswith(JDK_DIR): # Folder name matches <jdk-##> 
-                action(path) # Callback to run on each matching folder path
-                if only_1st: break # Stop at 1st match occurrence
-
-
-    @staticmethod
-    def get_all_thonny_folder_paths() -> Iterator[Path]:
-        '''Find all subfolder paths within Thonny's user folder'''
-        return filter(Path.is_dir, THONNY_USER_PATH.iterdir())
-
-
-    @staticmethod
-    def rename_folder(path: StrPath) -> None:
-        '''Rename a JDK subfolder to the expected jdk-<version##> format.'''
-        rename(path, JDK_PATH)

--- a/thonnycontrib/thonny-py5mode/install_jdk.py
+++ b/thonnycontrib/thonny-py5mode/install_jdk.py
@@ -1,6 +1,5 @@
-'''thonny-py5mode JDK installer
-   checks for JDK and, if not found, installs it to the Thonny config directory
-'''
+'''thonny-py5mode JDK installer.
+Checks for JDK and, if not found, installs it to Thonny's user directory.'''
 
 import re, shutil, jdk
 
@@ -10,7 +9,7 @@ from threading import Thread
 from os import environ as env, scandir, rename, PathLike
 from os.path import islink, realpath
 
-from typing import Callable, Literal, TypeAlias
+from typing import Any, Callable, Literal, TypeAlias
 from collections.abc import Iterable, Iterator
 
 import tkinter as tk
@@ -23,7 +22,7 @@ from thonny.languages import tr
 StrPath: TypeAlias = str | PathLike[str]
 '''A type representing string-based filesystem paths.'''
 
-PathAction: TypeAlias = Callable[[StrPath], None]
+PathAction: TypeAlias = Callable[[StrPath], Any]
 '''Represents an action applied to a single path-like object.'''
 
 JDK_PATTERN = re.compile(r"""
@@ -31,30 +30,44 @@ JDK_PATTERN = re.compile(r"""
     -?              # Match optional hyphen '-'
     (\d+)           # Capture JDK major version number as group(1)
 """, re.IGNORECASE | re.VERBOSE)
+'''Captures the major version number from strings like "java-17" or "jdk21".'''
 
-REQUIRE_JDK, VERSION_JDK = 17, '17' # Minimum required version
-DOWNLOAD_JDK = '21' # JDK version to download
-JDK_DIR = 'jdk-' + DOWNLOAD_JDK # JDK subfolder name
+REQUIRE_JDK, VERSION_JDK = 17, '17'
+'''JDK minimum required version to run Processing.'''
 
-THONNY_USER_PATH = Path(THONNY_USER_DIR) # Thonny folder's full path string
-JDK_PATH = THONNY_USER_PATH / JDK_DIR # Path for JDK subfolder
-JDK_HOME = str(JDK_PATH) # JDK subfolder's full path string
+DOWNLOAD_JDK = '21'
+'''JDK version to download.'''
 
-WORKBENCH = get_workbench() # Workbench singleton instance
+JDK_DIR = 'jdk-' + DOWNLOAD_JDK
+'''JDK install subfolder name.'''
+
+THONNY_USER_PATH = Path(THONNY_USER_DIR)
+'''Thonny user folder's full path string.'''
+
+JDK_PATH = THONNY_USER_PATH / JDK_DIR
+'''Path for JDK installation subfolder.'''
+
+JDK_HOME = str(JDK_PATH)
+'''JDK install subfolder's full path string.'''
+
+WORKBENCH = get_workbench()
+'''Thonny's workbench singleton instance.'''
 
 def install_jdk() -> None: # Module's main entry-point function
     '''Call this function from where this module is imported.'''
-    if is_java_home_set(): return # JAVA_HOME points to a required JDK version
+
+    if is_java_home_set(): return # JAVA_HOME already points to required version
 
     # Set a local JAVA_HOME to the detected JDK found in THONNY_USER_DIR:
     if path := get_thonny_jdk_install(): set_java_home(path)
 
     # Otherwise, if Thonny doesn't have a proper JDK version...
-    else: ui_utils.show_dialog(JdkDialog()) # ... ask permission to download it.
+    else: ui_utils.show_dialog(JdkDialog()) # ... ask permission to download 1.
 
 
 def is_java_home_set() -> bool:
     '''Check system for existing JDK that meets the py5 version requirements.'''
+
     if java_home := env.get('JAVA_HOME'): # Check if JAVA_HOME is already set
         system_jdk = 'TBD' # JDK version To-Be-Determined
 
@@ -73,6 +86,7 @@ def is_java_home_set() -> bool:
 def get_thonny_jdk_install() -> PurePath | Literal['']:
     '''Check Thonny's user folder for a JDK installation subfolder
     and return its path. Otherwise, return an empty string.'''
+
     for subfolder in get_all_thonny_folders(): # Loop over each subfolder name
         # Use regexp to check if subfolder contains a valid JDK name: 
         if match := JDK_PATTERN.search(subfolder):
@@ -89,8 +103,9 @@ def get_thonny_jdk_install() -> PurePath | Literal['']:
 
 def set_java_home(jdk_path: StrPath) -> None:
     '''Add JDK path to config file (tools > options > general > env vars).'''
+
     jdk_path = str(adjustjdk_path(jdk_path)) # Platform-adjusted path
-    env['JAVA_HOME'] = jdk_path # Python's process points to Thonny's JDK
+    env['JAVA_HOME'] = jdk_path # Python's process points to Thonny's JDK too
 
     jdk_path_entry = create_java_home_entry_from_path(jdk_path)
     env_vars: set[str] = set(WORKBENCH.get_option('general.environment'))
@@ -104,6 +119,7 @@ def set_java_home(jdk_path: StrPath) -> None:
 
 def adjustjdk_path(jdk_path: StrPath) -> PurePath:
     '''Adjust JDK path for the specificity of current platform.'''
+
     jdk_path = PurePath(jdk_path)
 
     # if MacOS, append "/Contents/Home/" to form the actual JDK path for it:
@@ -147,12 +163,11 @@ def get_all_thonny_folders() -> list[str]:
 
 class JdkDialog(ui_utils.CommonDialog):
     '''User-facing dialog prompting install of required JDK for py5 sketches.
-
     - Presents user with option to proceed or cancel the JDK installation.
     - Displays a horizontal indeterminate-sized progress bar during download.
     - Launches a background thread to handle installation tasks.
-    - Shows a success message when installation is complete.
-    '''
+    - Shows a success message when installation is complete.'''
+
     _TITLE = tr('Install JDK ' + DOWNLOAD_JDK + ' for py5')
 
     _PROGRESS = tr('Downloading and extracting JDK ' + DOWNLOAD_JDK + ' ...')
@@ -166,70 +181,65 @@ class JdkDialog(ui_utils.CommonDialog):
         "Thonny requires at least JDK " + VERSION_JDK + " to run py5 sketches. "
         "It'll need to download about 180 MB.")
 
-    _PAD = 0, 15
+    _PROGRESS_BAR_Y_PADDING = 0, 15
 
     def __init__(self, master=WORKBENCH, skip_diag_attribs=False, **kw):
         super().__init__(master, skip_diag_attribs, **kw)
 
-        # Window/Frame:
-        self.main_frame = ttk.Frame(self)
-        self.main_frame.grid(ipadx=15, ipady=15, sticky=tk.NSEW)
-        self.main_frame.rowconfigure(0, weight=1)
-        self.main_frame.columnconfigure(0, weight=1)
+        # Set dialog properties: title, fixed size, close button disabled:
+        self.title(self._TITLE) # Dialog title for JDK installation
+        self.resizable(height=tk.FALSE, width=tk.FALSE) # Prevent its resizing
+        self.protocol('WM_DELETE_WINDOW', '{#}') # Disable its close button
 
-        self.title(self._TITLE)
-        self.resizable(height=tk.FALSE, width=tk.FALSE)
-        self.protocol('WM_DELETE_WINDOW', '{#}') # Block window close button
+        # Window/Frame:
+        main_frame = self.main_frame = ttk.Frame(self)
+        main_frame.grid(ipadx=15, ipady=15, sticky=tk.NSEW)
+        main_frame.rowconfigure(0, weight=1)
+        main_frame.columnconfigure(0, weight=1)
 
         # Display install message:
-        message_label = ttk.Label(self.main_frame, text=self._INSTALL_JDK)
+        message_label = ttk.Label(main_frame, text=self._INSTALL_JDK)
         message_label.grid(pady=0, columnspan=2)
 
-        # OK button:
-        self.ok_button = ttk.Button(
-            self.main_frame,
+        # OK proceed button:
+        ok_button = self.ok_button = ttk.Button(
+            main_frame,
             text=self._OK,
             command=self._proceed,
             default=tk.ACTIVE)
 
-        self.ok_button.grid(
-            row=2, column=0,
-            padx=15, pady=15,
-            sticky=tk.W)
-
-        self.ok_button.focus_set()
+        ok_button.grid(row=2, column=0, padx=15, pady=15, sticky=tk.W)
+        ok_button.focus_set()
 
         # Cancel button:
-        self.cancel_button = ttk.Button(
-            self.main_frame,
+        cancel_button = self.cancel_button = ttk.Button(
+            main_frame,
             text=self._CANCEL,
             command=self._close)
 
-        self.cancel_button.grid(
-            row=2, column=1,
-            padx=15, pady=15,
-            sticky=tk.E)
+        cancel_button.grid(row=2, column=1, padx=15, pady=15, sticky=tk.E)
 
 
     def _proceed(self) -> None:
         '''Starts JDK downloader thread.'''
+
         # Get rid of both OK & Cancel buttons:
         if self.ok_button: self.ok_button.destroy()
         if self.cancel_button: self.cancel_button.destroy()
 
         # Progress bar label:
         dl_label = ttk.Label(self.main_frame, text=self._PROGRESS)
-        dl_label.grid(row=1, columnspan=2, pady=self._PAD)
+        dl_label.grid(row=1, columnspan=2, pady=self._PROGRESS_BAR_Y_PADDING)
 
         # Progress bar:
         progress_bar = ttk.Progressbar(self.main_frame, mode='indeterminate')
 
         progress_bar.grid(
             row=2, column=0, columnspan=2,
-            padx=15, pady=self._PAD,
+            padx=15, pady=self._PROGRESS_BAR_Y_PADDING,
             sticky=tk.EW)
 
-        # Start progress bar animation and download thread:
+        # Start progress bar animation + download thread:
         if self.main_frame: self.main_frame.tkraise()
 
         download_thread = DownloadJDK()
@@ -241,10 +251,12 @@ class JdkDialog(ui_utils.CommonDialog):
 
     def _monitor(self, download: Thread, progress: ttk.Progressbar) -> None:
         '''Animate progress bar while JDK installs and extracts.'''
+
         if download.is_alive():
             self.after(100, lambda: self._monitor(download, progress))
             return
 
+        # Destroy this JDK dialog instance once download has finished:
         progress.stop()
         self._close()
 
@@ -260,14 +272,14 @@ class JdkDialog(ui_utils.CommonDialog):
 
 class DownloadJDK(Thread):
     '''Background thread for downloading & installing JDK into Thonny's folder.
-
     - Removes any preexisting JDK folders matching the expected version.
     - Downloads and extracts the required JDK version.
     - Renames the downloaded folder to the expected format.
-    - Sets JAVA_HOME both in system environment and Thonny configuration.
-    '''
+    - Sets JAVA_HOME on Thonny configuration.'''
+
     def run(self) -> None:
-        '''Download and setup JDK (installs to Thonny's config directory)'''
+        '''Download and setup JDK (installs to Thonny's user directory)'''
+
         # Delete existing Thonny's JDK subfolders matching jdk-<version##>:
         self.process_matchjdk_dirs(shutil.rmtree)
 
@@ -283,6 +295,7 @@ class DownloadJDK(Thread):
     @staticmethod
     def process_matchjdk_dirs(action: PathAction, only_1st=False) -> None:
         '''Apply an action to JDK-matching subfolders in Thonny's folder.'''
+
         for path in DownloadJDK.get_all_thonny_folder_paths():
             if path.name.startswith(JDK_DIR): # Folder name matches <jdk-##> 
                 action(path) # Callback to run on each matching folder path


### PR DESCRIPTION
Plugin can now download JDK-21 if no minimum version is found.
But it still accepts versions before JDK-21 but >= JDK-17.
Also, this pull request has comment & code style refactors.

P.S.: Tested on a custom Thonny venv using Python 3.10.8 on Garuda (Arch-based) Linux 6.16.5 + KDE 6.4.4 (Wayland).