### PR TITLE
Refactor/backend

### DIFF
--- a/thonnycontrib/backend/py5_imported_mode_backend.py
+++ b/thonnycontrib/backend/py5_imported_mode_backend.py
@@ -32,7 +32,6 @@ def patched_editor_autocomplete(self: MainCPythonBackend, cmd) -> AutoComplete:
     cmd.row -= 1
     cmd.source = cmd.source[len(prefix):]
 
-
     return {
         'source': cmd.source,
         'row': cmd.row,

--- a/thonnycontrib/backend/py5_imported_mode_backend.py
+++ b/thonnycontrib/backend/py5_imported_mode_backend.py
@@ -4,9 +4,9 @@
 from os import environ as env
 from sys import path
 
-from typing import Optional, TypedDict, TypeAlias
+from typing import TypeAlias
 
-from thonny.common import InlineCommand, InlineResponse, CompletionInfo
+from thonny.common import CompletionInfo
 from thonny.plugins.cpython_backend import MainCPythonBackend
 from thonny import jedi_utils, get_sys_path_directory_containg_plugins
 
@@ -14,35 +14,30 @@ path.append( get_sys_path_directory_containg_plugins() )
 
 AutoComplete: TypeAlias = dict[str, list[CompletionInfo] | str | None]
 
-class Command(TypedDict):
-    source: str
-    row: int
-    column: int
-    filename: str
-    sys_path: Optional[list[str]]
-
-def patched_editor_autocomplete(self: MainCPythonBackend, cmd: Command) -> AutoComplete:
+def patched_editor_autocomplete(self: MainCPythonBackend, cmd) -> AutoComplete:
     '''Add py5 to autocompletion'''
 
     prefix = 'from py5 import *\n'
 
-    cmd['source'] = prefix + cmd['source']
-    cmd['row'] += 1
+    cmd.source = prefix + cmd.source
+    cmd.row += 1
 
-    result: Command = dict(
+    completions = jedi_utils.get_script_completions(
+        cmd.source,
+        cmd.row,
+        cmd.column,
+        cmd.filename,
+        sys_path=[get_sys_path_directory_containg_plugins()])
+
+    cmd.row -= 1
+    cmd.source = cmd.source[len(prefix):]
+
+    return dict(
         source=cmd.source,
         row=cmd.row,
         column=cmd.column,
-        filename=cmd.filename
-    )
-
-    result['completions'] = jedi_utils.get_script_completions(
-        **result, sys_path=[get_sys_path_directory_containg_plugins()])
-
-    result['row'] -= 1
-    result['source'] = result['source'][len(prefix):]
-
-    return result
+        filename=cmd.filename,
+        completions=completions)
 
 
 def load_plugin() -> None:
@@ -54,5 +49,4 @@ def load_plugin() -> None:
     # https://groups.Google.com/g/thonny/c/wWCeXWpKy8c
     c_e_a = MainCPythonBackend._cmd_editor_autocomplete
     setattr(MainCPythonBackend, '_original_editor_autocomplete', c_e_a)
-    # MainCPythonBackend._original_editor_autocomplete = c_e_a
     MainCPythonBackend._cmd_editor_autocomplete = patched_editor_autocomplete

--- a/thonnycontrib/backend/py5_imported_mode_backend.py
+++ b/thonnycontrib/backend/py5_imported_mode_backend.py
@@ -1,64 +1,58 @@
 '''thonny-py5mode backend
-   interacts with thonny-py5mode frontend (thonny-py5mode > __init__.py)
-'''
+   interacts with thonny-py5mode frontend (thonny-py5mode > __init__.py)'''
 
-import ast
-import os
-import pathlib
-import sys
-from py5_tools import imported
-from thonny import get_version
-from thonny.common import InlineCommand, InlineResponse
-try:  # thonny 4 package layout
-    from thonny import jedi_utils
-    from thonny.plugins.cpython_backend import (
-      get_backend,
-      MainCPythonBackend
-    )
-    # add plug-in packages to packages path
-    # https://groups.google.com/g/thonny/c/dhMOGXZHTDU
-    from thonny import get_sys_path_directory_containg_plugins
-    sys.path.append(get_sys_path_directory_containg_plugins())
-except ImportError:  # thonny 3 package layout
-    from thonny.plugins.cpython.cpython_backend import (
-      get_backend,
-      MainCPythonBackend
-    )
+from os import environ as env
+from sys import path
 
+from typing import Optional, TypedDict, TypeAlias
 
-def patched_editor_autocomplete(
-      self: MainCPythonBackend, cmd: InlineCommand) -> InlineResponse:
-    '''add py5 to autocompletion'''
+from thonny.common import InlineCommand, InlineResponse, CompletionInfo
+from thonny.plugins.cpython_backend import MainCPythonBackend
+from thonny import jedi_utils, get_sys_path_directory_containg_plugins
+
+path.append( get_sys_path_directory_containg_plugins() )
+
+AutoComplete: TypeAlias = dict[str, list[CompletionInfo] | str | None]
+
+class Command(TypedDict):
+    source: str
+    row: int
+    column: int
+    filename: str
+    sys_path: Optional[list[str]]
+
+def patched_editor_autocomplete(self: MainCPythonBackend, cmd: Command) -> AutoComplete:
+    '''Add py5 to autocompletion'''
+
     prefix = 'from py5 import *\n'
+
     cmd['source'] = prefix + cmd['source']
     cmd['row'] += 1
 
-    if int(get_version()[0]) >= 4:  # thonny 4 package layout
-        result = dict(
-          source=cmd.source,
-          row=cmd.row,
-          column=cmd.column,
-          filename=cmd.filename,
-        )
-        result['completions'] = jedi_utils.get_script_completions(
-          **result, sys_path=[get_sys_path_directory_containg_plugins()]
-        )
-    else:
-        result = get_backend()._original_editor_autocomplete(cmd)
+    result: Command = dict(
+        source=cmd.source,
+        row=cmd.row,
+        column=cmd.column,
+        filename=cmd.filename
+    )
+
+    result['completions'] = jedi_utils.get_script_completions(
+        **result, sys_path=[get_sys_path_directory_containg_plugins()])
 
     result['row'] -= 1
     result['source'] = result['source'][len(prefix):]
+
     return result
 
 
 def load_plugin() -> None:
-    '''every thonny plug-in uses this function to load'''
-    if os.environ.get('PY5_IMPORTED_MODE', 'False').lower() == 'false':
-        return
+    '''Every Thonny plug-in uses this function to load'''
+    if env.get('PY5_IMPORTED_MODE', 'False').lower() == 'false': return
 
-    # note that _cmd_editor_autocomplete is not a public api
-    # may need to treat different thonny versions differently
-    # https://groups.google.com/g/thonny/c/wWCeXWpKy8c
+    # Note that _cmd_editor_autocomplete() is not a public API
+    # May need to treat different Thonny versions differently:
+    # https://groups.Google.com/g/thonny/c/wWCeXWpKy8c
     c_e_a = MainCPythonBackend._cmd_editor_autocomplete
-    MainCPythonBackend._original_editor_autocomplete = c_e_a
+    setattr(MainCPythonBackend, '_original_editor_autocomplete', c_e_a)
+    # MainCPythonBackend._original_editor_autocomplete = c_e_a
     MainCPythonBackend._cmd_editor_autocomplete = patched_editor_autocomplete

--- a/thonnycontrib/backend/py5_imported_mode_backend.py
+++ b/thonnycontrib/backend/py5_imported_mode_backend.py
@@ -27,17 +27,18 @@ def patched_editor_autocomplete(self: MainCPythonBackend, cmd) -> AutoComplete:
         cmd.row,
         cmd.column,
         cmd.filename,
-        sys_path=[get_sys_path_directory_containg_plugins()])
+        sys_path=[ get_sys_path_directory_containg_plugins() ])
 
     cmd.row -= 1
     cmd.source = cmd.source[len(prefix):]
 
-    return dict(
-        source=cmd.source,
-        row=cmd.row,
-        column=cmd.column,
-        filename=cmd.filename,
-        completions=completions)
+
+    return {
+        'source': cmd.source,
+        'row': cmd.row,
+        'column': cmd.column,
+        'filename': cmd.filename,
+        'completions': completions }
 
 
 def load_plugin() -> None:
@@ -47,6 +48,7 @@ def load_plugin() -> None:
     # Note that _cmd_editor_autocomplete() is not a public API
     # May need to treat different Thonny versions differently:
     # https://groups.Google.com/g/thonny/c/wWCeXWpKy8c
+
     c_e_a = MainCPythonBackend._cmd_editor_autocomplete
     setattr(MainCPythonBackend, '_original_editor_autocomplete', c_e_a)
     MainCPythonBackend._cmd_editor_autocomplete = patched_editor_autocomplete


### PR DESCRIPTION
This is the "thonnycontrib/backend/py5_imported_mode_backend.py" cleanup.

However, after some testings, I've concluded this file can be deleted and it won't change the plugin's behavior!

Basically, this file adds 'from py5 import *\n' to a py5mode sketch.
But it seems like library py5 is somehow already doing that!

Therefore, my advice is to fully delete this "backend" folder from this plugin project!

https://github.com/py5coding/thonny-py5mode/issues/89